### PR TITLE
Client.Authorize error handling

### DIFF
--- a/tinder.js
+++ b/tinder.js
@@ -162,9 +162,9 @@ function TinderClient() {
           xAuthToken = body.token;
           _this.userId = body.user._id;
           _this.defaults = body;
-          callback(null, body);
+          callback(null, res, body);
         } else {
-          callback(error || true, null);
+          callback(error || true, res, null);
         }
       });
   };

--- a/tinder.js
+++ b/tinder.js
@@ -157,13 +157,14 @@ function TinderClient() {
         facebook_id: fbId
       },
       function(error, res, body) {
+        var body = body || { 'token': null };
         if (!error && body.token) {
           xAuthToken = body.token;
           _this.userId = body.user._id;
           _this.defaults = body;
-          callback(error, res, body);
-        } else if (body.error){
-          throw "Failed to authenticate: " + body.error
+          callback(null, body);
+        } else {
+          callback(error || true, null);
         }
       });
   };


### PR DESCRIPTION
modifications to client.authorize:
* if-statement on line 161 checks if body.token exists, but if it’s an
incorrect authentication it will throw an error that will crash a server. 
Remedied by short circuiting body to { 'token': null } 
* an incorrect login previously threw an error, now it passes the error
through to a callback. The error is short-circuited to be true, as i’ve
experienced times when an error is not thrown on incorrect login
attempts, but the function does not enter the first if-statement.

These changes seem to working out well so far on a side project I've got involving this library, no crashes yet. (https://tindalytics.herokuapp.com/)