### PR TITLE
Tinder API expects and returns distance in miles, not kilometres

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ client.authorize(
 * `min age` is the minimum age of incoming recommendations
 * `max age` is the maximum age of incoming recommendations
 * `gender` is the gender of incoming recommendations (0 = Male, 1 = Female, -1 = Both)
-* `distance` is the maximum distance in kilometers of incoming recommendations
+* `distance` is the maximum distance in miles of incoming recommendations
 * `callback` is called when the request completes
 
 ### .getProfile(callback)

--- a/tinder.js
+++ b/tinder.js
@@ -291,7 +291,7 @@ function TinderClient() {
    * @param {Number} ageMin the minimum age to show recommendations
    * @param {Number} ageMax the maximum age to show recommendations
    * @param {Number} gender the gender to show recommentations (0 = Male, 1 = Female, -1 = Both)
-   * @param {Number} distance the distance in km to show recommendations
+   * @param {Number} distance the distance in miles to show recommendations
    * @param {Function} callback the callback to invoke when the request completes
    */
   this.updatePreferences = function(discovery, ageMin, ageMax, gender, distance, callback) {


### PR DESCRIPTION
Seems incorrectly documented in the [gist documentation](https://gist.github.com/rtt/10403467) - the API uses miles for everything.